### PR TITLE
uuid

### DIFF
--- a/blitzdb/document.py
+++ b/blitzdb/document.py
@@ -278,12 +278,12 @@ class BaseDocument(object):
     def autogenerate_pk(self):
         """
         Autogenerates a primary key for this document. This function gets called by the backend
-        if you save a document without a primary key field. By default, it uses `uuid.uuid4().hex`
+        if you save a document without a primary key field. By default, it uses `uuid.uuid1().hex`
         to generate a (statistically) unique primary key for the object (`more about UUIDs <http://docs.python.org/2/library/uuid.html/>`_). 
         If you want to define your own primary key generation mechanism, just redefine this function
         in your document class.
         """
-        self.pk = uuid.uuid4().hex 
+        self.pk = uuid.uuid1().hex 
 
     @classmethod
     def get_pk_name(cls):


### PR DESCRIPTION
The uuid should have no collision. uuid1 seems to be the better choice, since there's almost no chance that someone would spoof their own mac address. uuid4 has the disadvantage of having a small collision chance, which isn't optimal in a database.

http://stackoverflow.com/questions/703035/when-are-you-truly-forced-to-use-uuid-as-part-of-the-design/786541#786541
