### PR TITLE
Added fix to allow the filter method sort_by argument to work

### DIFF
--- a/blitzdb/backends/file/backend.py
+++ b/blitzdb/backends/file/backend.py
@@ -496,7 +496,7 @@ class Backend(BaseBackend):
         return flatten(sort_by_keys(keys, sort_keys))
 
     def filter(self, cls_or_collection, query, sort_by=None, limit=None, offset=None, initial_keys=None):
-
+        
         if not isinstance(query, dict):
             raise AttributeError("Query parameters must be dict!")
 
@@ -526,8 +526,10 @@ class Backend(BaseBackend):
 
         # We collect all the indexes that we need to create
         compiled_query(index_collector)
-    
+        
         if indexes_to_create:
             self.create_indexes(cls, indexes_to_create, ephemeral=True)
-    
-        return compiled_query(query_function)
+        
+        query_set = compiled_query(query_function)
+        
+        return query_set.sort(sort_by) if sort_by else query_set #compiled_query(query_function)

--- a/blitzdb/tests/test_sorting.py
+++ b/blitzdb/tests/test_sorting.py
@@ -38,6 +38,23 @@ def test_basic_sorting(backend):
     for i in range(1, len(actors)):
         assert actors[i - 1].birth_year >= actors[i].birth_year
 
+    actors = backend.filter(Actor, {}).sort([('birth_year', -1)])
+    for i in range(1, len(actors)):
+        assert actors[i - 1].birth_year >= actors[i].birth_year
+
+    # Verify thet the filter sort_by is working corectly
+    actors = backend.filter(Actor, {}, sort_by='birth_year')
+    for i in range(1, len(actors)):
+        assert actors[i - 1].birth_year <= actors[i].birth_year
+
+    actors = backend.filter(Actor, {}, sort_by=[('seq', 1)])
+    for i in range(1, len(actors)):
+        assert actors[i - 1].birth_year <= actors[i].birth_year
+
+    actors = backend.filter(Actor, {}, sort_by=[('seq', -1)])
+    for i in range(1, len(actors)):
+        assert actors[i - 1].birth_year >= actors[i].birth_year
+
     """
     Objects with missing sort keys should be returned first when
     sorting in ascending order, else last.


### PR DESCRIPTION
This is linked to Github issue https://github.com/adewes/blitzdb/issues/25

Adds the usage of sort_by argument in FileBackend.filter() method

More details in the issue.
