### PR TITLE
Add basic unique indices

### DIFF
--- a/blitzdb/backends/file/__init__.py
+++ b/blitzdb/backends/file/__init__.py
@@ -1,4 +1,4 @@
 from blitzdb.backends.file.backend import Backend
 from blitzdb.backends.file.store import Store, TransactionalStore
-from blitzdb.backends.file.index import Index, TransactionalIndex, IndexUniquenessError
+from blitzdb.backends.file.index import Index, TransactionalIndex, Nonunique
 from blitzdb.backends.file.queryset import QuerySet

--- a/blitzdb/backends/file/__init__.py
+++ b/blitzdb/backends/file/__init__.py
@@ -1,4 +1,4 @@
 from blitzdb.backends.file.backend import Backend
 from blitzdb.backends.file.store import Store, TransactionalStore
-from blitzdb.backends.file.index import Index, TransactionalIndex
+from blitzdb.backends.file.index import Index, TransactionalIndex, IndexUniquenessError
 from blitzdb.backends.file.queryset import QuerySet

--- a/blitzdb/tests/fixtures.py
+++ b/blitzdb/tests/fixtures.py
@@ -4,6 +4,8 @@ import subprocess
 import time
 
 try:
+    # TODO: Remove for final commit; mongodb tests too slow...
+    raise ImportError
     import pymongo
     from blitzdb.backends.mongo import Backend as MongoBackend
     test_mongo = True

--- a/blitzdb/tests/fixtures.py
+++ b/blitzdb/tests/fixtures.py
@@ -5,7 +5,6 @@ import time
 
 try:
     # TODO: Remove for final commit; mongodb tests too slow...
-    raise ImportError
     import pymongo
     from blitzdb.backends.mongo import Backend as MongoBackend
     test_mongo = True

--- a/blitzdb/tests/fixtures.py
+++ b/blitzdb/tests/fixtures.py
@@ -4,7 +4,6 @@ import subprocess
 import time
 
 try:
-    # TODO: Remove for final commit; mongodb tests too slow...
     import pymongo
     from blitzdb.backends.mongo import Backend as MongoBackend
     test_mongo = True

--- a/blitzdb/tests/test_indexes.py
+++ b/blitzdb/tests/test_indexes.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+
+import pytest
+import tempfile
+
+from .fixtures import *
+from ..backends.file import Nonunique
+from blitzdb.tests.helpers.movie_data import Actor
+
+
+def test_nonunique_file_backend_index():
+    backend = file_backend(None, tempfile.mkdtemp(),
+                           {'serializer_class': 'pickle'},
+                           autoload_embedded=True)
+    backend.create_index(Actor, fields={'yob': 1})
+    actor1 = Actor({'yob': 1})
+    actor1.save(backend)
+    actor2 = Actor({'yob': 1})
+    actor2.save(backend)
+    backend.commit()
+    assert actor1.pk != actor2.pk
+
+
+def test_unique_file_backend_index():
+    backend = file_backend(None, tempfile.mkdtemp(),
+                           {'serializer_class': 'pickle'},
+                           autoload_embedded=True)
+    backend.create_index(Actor, fields={'num_films': 1}, unique=True)
+    actor1 = Actor({'num_films': 1})
+    actor1.save(backend)
+    actor2 = Actor({'num_films': 1})
+    actor2.save(backend)
+    with pytest.raises(Nonunique):
+        backend.commit()

--- a/blitzdb/tests/test_querying.py
+++ b/blitzdb/tests/test_querying.py
@@ -4,9 +4,8 @@ import pytest
 
 from .fixtures import *
 
-from blitzdb import Document, FileBackend
+from blitzdb import Document
 from blitzdb.tests.helpers.movie_data import Actor, Director, Movie
-
 
 
 def test_basic_delete(backend, small_test_data):

--- a/blitzdb/tests/test_querying.py
+++ b/blitzdb/tests/test_querying.py
@@ -6,7 +6,6 @@ from .fixtures import *
 
 from blitzdb import Document, FileBackend
 from blitzdb.tests.helpers.movie_data import Actor, Director, Movie
-from blitzdb.backends.file import IndexUniquenessError
 
 
 
@@ -295,17 +294,3 @@ def test_index_reloading(backend, small_test_data):
     backend.commit()
 
     assert list(backend.filter(Actor, {'movies': movies[0]})) == []
-
-
-def test_unique_index(backend):
-    # Not sure how to create unique indices in Mongo
-    if not isinstance(backend, FileBackend):
-        return
-    backend.create_index(Actor, "name", unique=True)
-    Actor({'name': 'Joe'}).save(backend)
-    Actor({'name': 'Frank'}).save(backend)
-    Actor({'name': 'Hans'}).save(backend)
-    backend.commit()
-    with pytest.raises(IndexUniquenessError):
-        Actor({'name': 'Joe'}).save(backend)
-        backend.commit()


### PR DESCRIPTION
Has some limitations:
* Raises an new error, `Nonunique`, but only when index is re/built.
* Only works with file backends.
* Works every time the method `.add_hashed_value` is called. 
* Tests are pretty basic, and don't fully utilize py.test capabilities.

This could be the starting point for a discussion on what this should look like, or could just be committed, if you think it is OK.

Sorry for whitespace diffs.