### PR TITLE
file backend: support query by lambda expression

### DIFF
--- a/blitzdb/backends/file/queries.py
+++ b/blitzdb/backends/file/queries.py
@@ -30,6 +30,14 @@ def filter_query(key, expression):
             and len(expression) == 1
             and list(expression.keys())[0].startswith('$')):
         compiled_expression = compile_query(expression)
+    elif callable(expression):
+        def _filter(index, expression=expression):
+            result = [store_key
+                      for value, store_keys in index.get_index().items()
+                      if expression(value)
+                      for store_key in store_keys]
+            return result
+        compiled_expression = _filter
     else:
         compiled_expression = expression
 

--- a/blitzdb/tests/fixtures.py
+++ b/blitzdb/tests/fixtures.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 import tempfile
 import subprocess


### PR DESCRIPTION
- modified file.queries.filter_query to take a lambda expression
  and iterate over the index filtering based on the expression.

- also changed @pytest.skip to @pytest.mark.skipif in a case where
  it was causing the entire file to be skipped

fixes #58