### PR TITLE
Fix broken Markdown headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Blitz-DB
+# Blitz-DB
 
 [![Build Status](https://travis-ci.org/adewes/blitzdb.svg?branch=master)](https://travis-ci.org/adewes/blitzdb)
 [![PyPI](https://img.shields.io/pypi/v/blitzdb.svg?maxAge=1000)](https://pypi.python.org/pypi/blitzdb)
@@ -7,9 +7,9 @@
 
 **BlitzDB**, or just **Blitz** is a document-based, object-oriented, transactional database written purely in Python. Among other things, it provides a **powerful querying language**, **deep indexing of documents**, **compressed data storage** and **automatic referencing of embedded documents**. It is reasonably fast, can be easily embedded in any Python application and does not have any external dependencies (except when using a third-party backend). In addition, you can use it as a **frontend** to other database engines such as MongoDB in case you should need more power.
 
-##[Go To Main Documentation](http://blitzdb.readthedocs.org)
+## [Go To Main Documentation](http://blitzdb.readthedocs.org)
 
-##Key Features
+## Key Features
 
 * Document-based, object-oriented interface.
 * Powerful and rich querying language.
@@ -18,11 +18,11 @@
 * Support for multiple backends (e.g. file-based storage, MongoDB).
 * Support for database transactions (currently only for the file-based backend).
 
-##Use Cases
+## Use Cases
 
 Blitz can be used as a standalone document store for client application. Originally blitz was designed for use with the [checkmate](https://github.com/quantifiedcode/checkmate) Python code analysis toolkit, where it stores statistical data. Since blitz stores all documents as single JSON files, it is possible to put the whole database under version-control.
 
-##Installation
+## Installation
 
 The easiest way to install Blitz is through **pip** or **easy_install**
 
@@ -32,11 +32,11 @@ The easiest way to install Blitz is through **pip** or **easy_install**
 
 For more detailed installation instructions, have a look at the [documentation](http://blitzdb.readthedocs.org).
 
-##Detailed Documentation
+## Detailed Documentation
 
 The detailed documentation for this project is hosted on [ReadTheDocs](http://blitzdb.readthedocs.org), feel free to take a look!
 
-##Changelog
+## Changelog
 
 * 0.3.0: Fully functional SQL backend.
 * 0.2.12: Added support for proper attribute iteration to `Document`.
@@ -61,7 +61,7 @@ The detailed documentation for this project is hosted on [ReadTheDocs](http://bl
 * 0.1.2: Small bugfixes, BlitzDB version number now contained in DB config dict
 * 0.1.1: BlitzDB is now Python3 compatible (thanks to David Koblas)
 
-##Contributors (in alphabetical order)
+## Contributors (in alphabetical order)
 
 *  @bwiessneth 
 *  Florian Lehmann - @cashaddy
@@ -84,15 +84,15 @@ The detailed documentation for this project is hosted on [ReadTheDocs](http://bl
 
 Thanks for all your contributions, without you BlitzDB wouldn't be what it is today :)
 
-##Third-Party Contributions
+## Third-Party Contributions
 
 * [Flask-BlitzDB](https://github.com/puredistortion/flask-blitzdb) Flask adapter for BlitzDB. Blitz + Flask = Awesome!
 
-##Examples
+## Examples
 
 To get an idea of what you can do with Blitz, here are some examples.
 
-###Creating objects
+### Creating objects
 
 ```python
 from blitzdb import Document
@@ -109,7 +109,7 @@ marlon_brando = Actor({'name':'Marlon Brando','pk':1L})
 al_pacino = Actor({'name' : 'Al Pacino','pk':1L})
 ```
 
-###Storing objects in the database:
+### Storing objects in the database:
 
 ```python
 from blitzdb import FileBackend
@@ -121,7 +121,7 @@ marlon_brando.save(backend)
 al_pacino.save(backend)
 ```
     
-###Retrieving objects from the database:
+### Retrieving objects from the database:
 
 ```python
 the_godfather = backend.get(Movie,{'pk':1L})
@@ -129,13 +129,13 @@ the_godfather = backend.get(Movie,{'pk':1L})
 the_godfather = backend.get(Movie,{'name' : 'The Godfather'})
 ```
     
-###Filtering objects
+### Filtering objects
 
 ```python
 movies_from_1972 = backend.filter(Movie,{'year' : 1972})
 ```
 
-###Working with transactions
+### Working with transactions
 
 ```python
 backend.begin()
@@ -144,7 +144,7 @@ the_godfather.save()
 backend.rollback() #undo the changes...
 ```
 
-###Creating nested object references
+### Creating nested object references
    
 ```python
 the_godfather.cast = {'Don Vito Corleone' : marlon_brando, 'Michael Corleone' : al_pacino}
@@ -160,7 +160,7 @@ the_godfather.save(backend)
 #Will store references to the movies within the documents in the DB
 ```
 
-###Creation of database indexes and advanced querying
+### Creation of database indexes and advanced querying
 
 ```python
 backend.create_index(Actor,'performances')
@@ -170,7 +170,7 @@ godfather_cast = backend.filter(Actor,{'movies' : the_godfather})
 #Will return 'Al Pacino' and 'Marlon Brando'
 ```
 
-###Arbitrary filter expressions
+### Arbitrary filter expressions
 
 ```python
 star_wars_iv = Movie({'name' : 'Star Wars - Episode IV: A New Hope','year': 1977})


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1