### PR TITLE
docs: Fix a few typos

### DIFF
--- a/blitzdb/backends/file/backend.py
+++ b/blitzdb/backends/file/backend.py
@@ -57,7 +57,7 @@ class Backend(BaseBackend):
     Uses flat files to store objects on the hard disk and file-based indexes to
     optimize querying.
 
-    :param path: The path to the database. If non-existant it will be created
+    :param path: The path to the database. If non-existent it will be created
     :param config:
         The configuration dictionary. If not specified, Blitz will try to load
         it from disk.  If this fails, the default configuration will be used

--- a/blitzdb/backends/file/index.py
+++ b/blitzdb/backends/file/index.py
@@ -158,7 +158,7 @@ class Index(object):
 
         :param keys: Keys to be sorted
         :type keys: list(str)
-        :param order: Order criteri (asending or descending)
+        :param order: Order criteri (ascending or descending)
         :type order: int
         :return: Sorted keys
         :rtype: list(str)

--- a/blitzdb/backends/sql/backend.py
+++ b/blitzdb/backends/sql/backend.py
@@ -946,7 +946,7 @@ class Backend(BaseBackend):
                         raise AttributeError("Included field '{}' is not a related object!".format(main_include))
                     #if we ask for github_data and github_data.full_name is an index field, we
                     #need to fetch both the `data` field and the github_data_full_name index field.
-                    #by adding the . we make sure that we won't inlcude e.g. committer_date
+                    #by adding the . we make sure that we won't include e.g. committer_date
                     #if committer_date_ts is asked for.
                     for key,params in self._index_fields[collection].items():
                         if key == main_include:
@@ -977,7 +977,7 @@ class Backend(BaseBackend):
                 else:
                     include['lazy'] = False
 
-        #we add the order_by_keys seperately
+        #we add the order_by_keys separately
         #(these should not influence whether a document is fetched lazily or not)
         for order_by_key in order_by_keys:
             resolve_include(order_by_key,collection,include_params)

--- a/docs/source/backends/index.rst
+++ b/docs/source/backends/index.rst
@@ -17,7 +17,7 @@ Currently, Blitz comes with two preinstalled backends:
     MongoDB <mongo>
 
 
-* :doc:`Native Backend <file>` The **native backend**, which we sometimes refer to as the **file-based backend** uses a file-based index and flat files to store objects in a local directory. It has not any external dependencies and is usually sufficent for most low- to mid-end applications.
+* :doc:`Native Backend <file>` The **native backend**, which we sometimes refer to as the **file-based backend** uses a file-based index and flat files to store objects in a local directory. It has not any external dependencies and is usually sufficient for most low- to mid-end applications.
 
 * :doc:`MongoDB Backend <mongo>` The **MongoDB backend** uses `PyMongo <http://api.mongodb.org/python/2.7rc0/>`_ to store and retrieve documents from a MongoDB database. It can be used in high-end applications, where use of a professional database engine is advocated.
 

--- a/docs/source/tutorials/basics.rst
+++ b/docs/source/tutorials/basics.rst
@@ -107,7 +107,7 @@ In addition, since Blitz is a **transactional database**, we have to call the :p
 
 .. note:: 
 
-    Use the :py:meth:`Backend.begin <blitzdb.backends.file.Backend.begin>` function to start a new database transaction and the :py:meth:`Backend.rollback <blitzdb.backends.file.Backend.rollback>` function to roll back the state of the database to the beginning of a transaction, if needed. By default, Blitz uses a **local isolation level** for transactions, so changes you make to the state of the database will be visible to parts of your program using the same backend, but will only be written to disk when :py:meth:`Backend.commit <blitzdb.backends.file.Backend.commit>` is invoked. If you like autocommits set the :py:meth:`Backend.autocomit <blitzdb.backends.file.Backend.autocommit>` to True after instantiating the backend
+    Use the :py:meth:`Backend.begin <blitzdb.backends.file.Backend.begin>` function to start a new database transaction and the :py:meth:`Backend.rollback <blitzdb.backends.file.Backend.rollback>` function to roll back the state of the database to the beginning of a transaction, if needed. By default, Blitz uses a **local isolation level** for transactions, so changes you make to the state of the database will be visible to parts of your program using the same backend, but will only be written to disk when :py:meth:`Backend.commit <blitzdb.backends.file.Backend.commit>` is invoked. If you like autocommits set the :py:meth:`Backend.autocommit <blitzdb.backends.file.Backend.autocommit>` to True after instantiating the backend
 
 Retrieving Documents
 --------------------
@@ -228,10 +228,10 @@ Like MongoDB, Blitz supports advanced query operators, which you can include in 
 
 * **$and** : Performs a boolean **AND** on two or more expressions
 * **$or** : Performs a boolean **OR** on two or more expressions
-* **$gt** : Performs a **>** comparision between an attribute and a specified value
-* **$gte** : Performs a **>=** comparision between an attribute and a specified value
-* **$lt** : Performs a **<** comparision between an attribute and a specified value
-* **$lte** : Performs a **<=** comparision between an attribute and a specified value
+* **$gt** : Performs a **>** comparison between an attribute and a specified value
+* **$gte** : Performs a **>=** comparison between an attribute and a specified value
+* **$lt** : Performs a **<** comparison between an attribute and a specified value
+* **$lte** : Performs a **<=** comparison between an attribute and a specified value
 * **$all** : Returns documents containing all values in the argument list.
 * **$in** : Returns documents matching at least one of the values in the argument list.
 * **$ne** : Performs a **not equal** operation on the given expression

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -40,7 +40,7 @@ def test_basic_sorting(backend):
     backend.commit()
     actors = list(backend.filter(Actor, {}).sort([('birth_year', 1)]))
     assert actor_wo_birth_year in actors
-    #SQL backends can produce ambigous results depending on how NULLS FIRST is implemented
+    #SQL backends can produce ambiguous results depending on how NULLS FIRST is implemented
     #this varies e.g. between Postgres and SQLite (which does not even support NULLS FIRST)
     if not isinstance(backend,SqlBackend):
         assert actors[0] == actor_wo_birth_year


### PR DESCRIPTION
There are small typos in:
- blitzdb/backends/file/backend.py
- blitzdb/backends/file/index.py
- blitzdb/backends/sql/backend.py
- docs/source/backends/index.rst
- docs/source/tutorials/basics.rst
- tests/test_sorting.py

Fixes:
- Should read `comparison` rather than `comparision`.
- Should read `sufficient` rather than `sufficent`.
- Should read `separately` rather than `seperately`.
- Should read `include` rather than `inlcude`.
- Should read `existent` rather than `existant`.
- Should read `autocommit` rather than `autocomit`.
- Should read `ascending` rather than `asending`.
- Should read `ambiguous` rather than `ambigous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md